### PR TITLE
minor updates to tighten the output and better structure for each PR id

### DIFF
--- a/.github/workflows/globalworkflow-ci.yaml
+++ b/.github/workflows/globalworkflow-ci.yaml
@@ -1,13 +1,20 @@
 name: gw-ci-orion
-# A GitHub Action that creates a deployment for a PR, clones, builds and runs a test suite
-# This workflow is triggered by a label being added to a PR name Orion-Ready
 
 on: [workflow_dispatch]
 
+# TEST_DIR contains 2 directories;
+# 1. HOMEgfs: clone of the global-workflow
+# 2. RUNTESTS: A directory containing EXPDIR and COMROT for experiments
+# e.g. $> tree ./TEST_DIR
+# ./TEST_DIR
+# ├── HOMEgfs
+# └── RUNTESTS
+#     ├── COMROT
+#     │   └── ${pslot}
+#     └── EXPDIR
+#         └── ${pslot}
 env:
-  id: ${{ github.run_id }}
-  HOMEgfs_PR: ${{ github.workspace }}/${{ github.run_id }}
-  RUNTESTS: ${{ github.workspace }}/RUNTESTS/${{ github.run_id }}
+  TEST_DIR: ${{ github.workspace }}/${{ github.run_id }}
   MACHINE_ID: orion
 
 jobs:
@@ -16,24 +23,24 @@ jobs:
     timeout-minutes: 600
 
     steps:
-    - name: Checkout
+    - name: Checkout global-workflow
       uses: actions/checkout@v3
       with:
-        path: ${{ github.run_id }}
+        path: ${{ github.run_id }}/HOMEgfs  # This path needs to be relative
 
     - name: Checkout components
       run: |
-        cd ${{ env.HOMEgfs_PR }}/sorc
+        cd ${{ env.TEST_DIR }}/HOMEgfs/sorc
         ./checkout.sh -c -g  # Options e.g. -u can be added late
 
     - name: Build components
       run: |
-        cd ${{ env.HOMEgfs_PR }}/sorc
+        cd ${{ env.TEST_DIR }}/HOMEgfs/sorc
         ./build_all.sh
 
     - name: Link artifacts
       run: |
-        cd ${{ env.HOMEgfs_PR }}/sorc
+        cd ${{ env.TEST_DIR }}/HOMEgfs/sorc
         ./link_workflow.sh
 
   create-experiments:
@@ -41,17 +48,19 @@ jobs:
     runs-on: [self-hosted, orion-ready]
     strategy:
       matrix:
-       case: ["C48_S2S","C96_atm3DVar"]
+        case: ["C48_S2S", "C96_atm3DVar"]
 
     steps:
       - name: Create Experiments ${{ matrix.case }}
         env:
+          HOMEgfs_PR: ${{ env.TEST_DIR }}/HOMEgfs
+          RUNTESTS: ${{ env.TEST_DIR }}/RUNTESTS
           pslot: ${{ matrix.case }}.${{ github.run_id }}
         run: |
-         cd ${{ env.HOMEgfs_PR }}
-         source workflow/gw_setup.sh
-         source ci/platforms/orion.sh
-         ./ci/scripts/create_experiment.py --yaml ci/cases/${{ matrix.case }}.yaml --dir ${{ env.HOMEgfs_PR }}
+          cd ${{ env.TEST_DIR }}/HOMEgfs
+          source workflow/gw_setup.sh
+          source ci/platforms/orion.sh
+          ./ci/scripts/create_experiment.py --yaml ci/cases/${{ matrix.case }}.yaml --dir ${{ env.HOMEgfs_PR }}
 
   run-experiments:
     needs: create-experiments
@@ -59,11 +68,19 @@ jobs:
     strategy:
       max-parallel: 2
       matrix:
-       case: ["C48_S2S", "C96_atm3DVar"]
+        case: ["C48_S2S", "C96_atm3DVar"]
     steps:
       - name: Run Experiment ${{ matrix.case }}
-        env:
-          id: ${{ env.id }}
         run: |
-         cd ${{ env.HOMEgfs_PR }}
-         ./ci/scripts/run-check_ci.sh ${{ env.HOMEgfs_PR }} ${{ env.RUNTESTS }}/EXPDIR ${{ matrix.case }}.${{ github.run_id }}
+          cd ${{ env.TEST_DIR }}/HOMEgfs
+          ./ci/scripts/run-check_ci.sh ${{ env.TEST_DIR }} ${{ matrix.case }}.${{ github.run_id }}
+
+  clean-up:
+    needs: run-experiments
+    runs-on: [self-hosted, orion-ready]
+    steps:
+      - name: Clean-up
+        run: |
+          cd ${{ github.workspace }}
+          rm -rf ${{ github.run_id }}
+

--- a/ci/scripts/run-check_ci.sh
+++ b/ci/scripts/run-check_ci.sh
@@ -1,25 +1,42 @@
 #!/bin/bash
 
+set -eu
+
 #####################################################################################
-#
-# Script description: BASH script for checking for cases in a given PR and
-#                     simply running rocotorun on each.  This script is intended
-#                     to run from within a cron job in the CI Managers account
+# Script description: script to check the status of an experiment as reported
+#                     by Rocoto
 #####################################################################################
 
-HOMEgfs=${1:-${HOMEgfs:-?}}
-EXPDIR=${2:-${EXPDIR:-?}}
-pslot=${3:-${pslot:-?}}
+TEST_DIR=${1:-${TEST_DIR:-?}}  # Location of the root of the testing directory
+pslot=${2:-${pslot:-?}}        # Name of the experiment being tested by this script
 
-source "${HOMEgfs}/ush/preamble.sh"
+# TEST_DIR contains 2 directories;
+# 1. HOMEgfs: clone of the global-workflow
+# 2. RUNTESTS: A directory containing EXPDIR and COMROT for experiments
+# # e.g. $> tree ./TEST_DIR
+# ./TEST_DIR
+# ├── HOMEgfs
+# └── RUNTESTS
+#     ├── COMROT
+#     │   └── ${pslot}
+#     └── EXPDIR
+#         └── ${pslot}
+HOMEgfs="${TEST_DIR}/HOMEgfs"
+RUNTESTS="${TEST_DIR}/RUNTESTS"
+
+# Source modules and setup logging
 source "${HOMEgfs}/workflow/gw_setup.sh"
 
-xml="${EXPDIR}/${pslot}/${pslot}.xml"
-db="${EXPDIR}/${pslot}/${pslot}.db"
+# cd into the experiment directory
+cd "${RUNTESTS}/EXPDIR/${pslot}" || (echo "FATAL ERROR: Unable to cd into '${RUNTESTS}/EXPDIR/${pslot}', ABORT!"; exit 1)
+
+# Name of the Rocoto XML and database files
+xml="${pslot}.xml"
+db="${pslot}.db"
 
 # Ensure the XML is present for the experiment
 if [[ ! -f "${xml}" ]]; then
-  echo "XML file ${xml} not found, experiment ${pslot} failed"
+  echo "FATAL ERROR: XML file ${xml} not found in '${pslot}', experiment ${pslot} failed, ABORT!"
   exit 1
 fi
 
@@ -30,13 +47,14 @@ while true; do
   rocotorun -v 10 -w "${xml}" -d "${db}"
 
   # Wait before running rocotostat
-  sleep 30
+  echo "wait 30s"; sleep 30
   if [[ ! -f "${db}" ]]; then
     echo "Database file ${db} not found, experiment ${pslot} failed"
     exit 2
   fi
 
   # Get job statistics
+  echo "Gather Rocoto statistics"
   rocotostat_output=$(rocotostat -w "${xml}" -d "${db}" -s | grep -v CYCLE) || true
   num_cycles=$(echo "${rocotostat_output}" | wc -l) || true
   num_done=$(echo "${rocotostat_output}" | grep -c Done) || true
@@ -47,16 +65,16 @@ while true; do
 
   if [[ ${num_failed} -ne 0 ]]; then
     {
-      echo "Experiment ${pslot} Terminated: *FAILED*"
       echo "Experiment ${pslot} Terminated with ${num_failed} tasks failed at $(date)" || true
-    } >> "${HOMEgfs}/global-workflow.log"
+      echo "Experiment ${pslot} Terminated: *FAILED*"
+    } >> "${RUNTESTS}/ci.log"
 
     error_logs=$(rocotostat -d "${db}" -w "${xml}" | grep -E 'FAIL|DEAD' | awk '{print "-c", $1, "-t", $2}' | xargs rocotocheck -d "${db}" -w "${xml}" | grep join | awk '{print $2}') || true
     {
      echo "Error logs:"
      echo "${error_logs}"
-    } >> "${HOMEgfs}/global-workflow.log"
-    sed -i "s/\`\`\`//2g" "${HOMEgfs}/global-workflow.log"
+    } >> "${RUNTESTS}/ci.log"
+    sed -i "s/\`\`\`//2g" "${RUNTESTS}/ci.log"
     sacct --format=jobid,jobname%35,WorkDir%100,stat | grep "${pslot}" | grep "${pr}\/RUNTESTS" |  awk '{print $1}' | xargs scancel || true
     rc=1
     break
@@ -64,11 +82,11 @@ while true; do
 
   if [[ "${num_done}" -eq "${num_cycles}" ]]; then
     {
-      echo "Experiment ${pslot} completed: *SUCCESS*"
       echo "Experiment ${pslot} Completed at $(date)" || true
       echo "with ${num_succeeded} successfully completed jobs" || true
-    } >> "${HOMEgfs}/global-workflow.log"
-    sed -i "s/\`\`\`//2g" "${HOMEgfs}/global-workflow.log"
+      echo "Experiment ${pslot} Completed: *SUCCESS*"
+    } >> "${RUNTESTS}/ci.log"
+    sed -i "s/\`\`\`//2g" "${RUNTESTS}/ci.log"
     rc=0
     break
   fi

--- a/ci/scripts/run-check_ci.sh
+++ b/ci/scripts/run-check_ci.sh
@@ -25,9 +25,11 @@ HOMEgfs="${TEST_DIR}/HOMEgfs"
 RUNTESTS="${TEST_DIR}/RUNTESTS"
 
 # Source modules and setup logging
+echo "Source modules."
 source "${HOMEgfs}/workflow/gw_setup.sh"
 
 # cd into the experiment directory
+echo "cd ${RUNTESTS}/EXPDIR/${pslot}"
 cd "${RUNTESTS}/EXPDIR/${pslot}" || (echo "FATAL ERROR: Unable to cd into '${RUNTESTS}/EXPDIR/${pslot}', ABORT!"; exit 1)
 
 # Name of the Rocoto XML and database files
@@ -40,18 +42,24 @@ if [[ ! -f "${xml}" ]]; then
   exit 1
 fi
 
+# Launch experiment
+echo "Launch experiment with Rocoto."
+rocotorun -v 10 -w "${xml}" -d "${db}"
+sleep 30
+if [[ ! -f "${db}" ]]; then
+  echo "FATAL ERROR: Rocoto database file ${db} not found, experiment ${pslot} failed, ABORT!"
+  exit 2
+fi
+
+# Experiment launched
 rc=99
 while true; do
 
-  echo "Running: rocotorun -v 10 -w ${xml} -d ${db}"
-  rocotorun -v 10 -w "${xml}" -d "${db}"
+  echo "Run rocotorun."
+  rocotorun -v ${ROCOTO_VERBOSE:-0} -w "${xml}" -d "${db}"
 
   # Wait before running rocotostat
-  echo "wait 30s"; sleep 30
-  if [[ ! -f "${db}" ]]; then
-    echo "Database file ${db} not found, experiment ${pslot} failed"
-    exit 2
-  fi
+  sleep 30
 
   # Get job statistics
   echo "Gather Rocoto statistics"


### PR DESCRIPTION
I defined a `TEST_DIR` as the ROOT of all tests for a given run_id.
I also added a clean-up task at the end of the workflow.